### PR TITLE
v1.2.0: Add CDN build to Typehead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.0
+
+- If `globalName` is specified in `typehead.config.js`, then a fourth IIFE ("CDN") build will be created with that name.
+
 # v1.1.0
 
 - 🚨 [breaking change] Upgrade from ESBuild 0.12.0 to 0.14.0.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ This behavior is configurable ([see below](#Customization)).
 - A production CSM build `index.js` that is minified.
 - A production ESM build `index-esm.js` that is not minified.
 
+If `globalName` is specified in [customization](#customization), then a fourth build will be created with that name.
+
+- A production IIFE build `{globalName}.js` that is minified and includes all dependencies statically.
+
+The IIFE build is suitable for distribution on CDNs.
+
 ## Serve
 
 `typehead serve` will start a web server for the `web` directory (if present).

--- a/example/typehead.config.cjs
+++ b/example/typehead.config.cjs
@@ -4,4 +4,5 @@ module.exports = {
   loader: {
     '.css': 'text',
   },
+  globalName: 'example'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/typehead",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/typehead",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Refreshingly simple CLI for TypeScript packages.",
   "main": "index.mjs",
   "type": "module",

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -115,6 +115,8 @@ if (config.globalName) {
         entryNames: `[dir]/${config.globalName}`,
         format: 'iife',
         minify: true,
+        bundle: true,
+        platform: 'browser'
       }),
     ]);
   } catch (e) {

--- a/src/build.mjs
+++ b/src/build.mjs
@@ -21,23 +21,7 @@ const program = new Command()
 const argv = program.opts();
 
 // Get base ESBuild config.
-const config = deepmerge(await getEsbuildConfig(), {
-  plugins: [
-    /**
-     * Small ESBuild plugin not to bundle node_modules:
-     * https://github.com/evanw/esbuild/issues/619#issuecomment-751995294
-     */
-    {
-      name: 'make-all-packages-external',
-      setup(build) {
-        build.onResolve({ filter: IS_EXTERNAL }, (args) => ({
-          path: args.path,
-          external: true,
-        }));
-      },
-    },
-  ],
-});
+const config = await getEsbuildConfig();
 
 // Make sure we're setting a default entry point and outdir.
 if (!config.entryPoints) {
@@ -74,24 +58,44 @@ if (argv.watch) {
 const now1 = Date.now();
 console.log(chalk.blue('Build starting! 🏗️'));
 
+// 'pkgConfig' includes make-all-packages-external, which for NPM
+// distribution is what we want.
+const pkgConfig = deepmerge(config, {
+  plugins: [
+    /**
+     * Small ESBuild plugin not to bundle node_modules:
+     * https://github.com/evanw/esbuild/issues/619#issuecomment-751995294
+     */
+    {
+      name: 'make-all-packages-external',
+      setup(build) {
+        build.onResolve({ filter: IS_EXTERNAL }, (args) => ({
+          path: args.path,
+          external: true,
+        }));
+      },
+    },
+  ],
+});
+
 try {
   await Promise.all([
     // Development build.
     esbuild.build({
-      ...config,
+      ...pkgConfig,
       entryNames: '[dir]/[name]-development',
       format: 'cjs',
     }),
     // Production build.
     esbuild.build({
-      ...config,
+      ...pkgConfig,
       entryNames: '[dir]/[name]',
       format: 'cjs',
       minify: true,
     }),
     // ESM build.
     esbuild.build({
-      ...config,
+      ...pkgConfig,
       entryNames: '[dir]/[name]-esm',
       format: 'esm',
     }),
@@ -99,6 +103,24 @@ try {
 } catch (e) {
   console.error(chalk.red('Build failed. ⚔️'));
   console.error(e);
+}
+
+// If we have a global name, create a build for CDN.
+if (config.globalName) {
+  try {
+    await Promise.all([
+      // CDN build.
+      esbuild.build({
+        ...config,
+        entryNames: `[dir]/${config.globalName}`,
+        format: 'iife',
+        minify: true,
+      }),
+    ]);
+  } catch (e) {
+    console.error(chalk.red('Build failed. ⚔️'));
+    console.error(e);
+  }
 }
 
 const now2 = Date.now();


### PR DESCRIPTION
# Description

When [`globalName`](https://esbuild.github.io/api/#global-name) is specified in `typehead.config.js`, we generate an additional `{globalName}.js` in the `dist/` folder with the following options:

- **NO** `make-all-packages-external`, bundling all dependencies.
- `minify: true`
- `format: "iife"` (https://esbuild.github.io/api/#format-iife)

This would allow someone on [UNPKG](https://unpkg.com/) or our CDN to access a "CDN" build automatically.

Example:

`index.ts`:

```typescript
export hello() {
  return "world!";
}
```

```typescript.config.js```:

```javascript
{
  globalName: "somepackage"
}
```

`package.json`:

```json
{
  "name": "some-package",
  "unpkg": "dist/some-package.js"
}
```

foreign `index.html`:

```html
<script src="https://unpkg.com/some-package" /><script>
<script>
  somepackage.hello() // = world!
</script>
```

Mapbox or another private CDN could just upload the `dist/some-package.js` file as well.