### PR TITLE
Prepare v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.2.1
+
+- Allow for `"platform": "node"` to be specified and not overridden.
+
 # v1.2.0
 
 - If `globalName` is specified in `typehead.config.js`, then a fourth IIFE ("CDN") build will be created with that name.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your `package.json`:
 {
   "main": "dist/index.js",
   "module": "dist/index-esm.js",
-  "typings": "dist/index.d.ts",
+  "typings": "dist/src/index.d.ts",
   "scripts": {
     "build": "typehead build",
     "watch": "typehead build --watch",

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ In your `package.json`:
 
 Typehead will not check types or generate declaration files. While this seems initially counter-intuitive, this operation is costly and usually covered by IDE tools (VSCode) and CI (using `tsc`).
 
-We recommend setting this up with `npm install --save-dev dts-bundle-generator`.
+We recommend setting this up with `tsc`, which is included with TypeScript.
 
 Here's an example in `package.json` that builds types before publishing to NPM:
 
 ```json
 {
   "scripts": {
-    "types": "dts-bundle-generator -o dist/index.d.ts src/index.ts",
+    "types": "tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir ./dist",
     "prepare": "npm run types && npm run build"
   }
 }
@@ -48,11 +48,21 @@ This behavior is configurable ([see below](#Customization)).
 - A production CSM build `index.js` that is minified.
 - A production ESM build `index-esm.js` that is not minified.
 
+### Global name
+
 If `globalName` is specified in [customization](#customization), then a fourth build will be created with that name.
 
 - A production IIFE build `{globalName}.js` that is minified and includes all dependencies statically.
 
-The IIFE build is suitable for distribution on CDNs.
+The IIFE build is suitable for distribution on CDNs and [UNPKG](https://unpkg.com/).
+
+`package.json`:
+
+```
+{
+  "unpkg": "dist/{globalName}.js"
+}
+```
 
 ## Serve
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your `package.json`:
 {
   "main": "dist/index.js",
   "module": "dist/index-esm.js",
-  "typings": "dist/src/index.d.ts",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "build": "typehead build",
     "watch": "typehead build --watch",
@@ -25,12 +25,28 @@ Typehead will not check types or generate declaration files. While this seems in
 
 We recommend setting this up with `tsc`, which is included with TypeScript.
 
-Here's an example in `package.json` that builds types before publishing to NPM:
+Here's an example that builds types before publishing to NPM:
+
+`tsconfig.types.json`:
+
+```json
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/*", "src/**/*"]
+}
+```
+
+`package.json`:
 
 ```json
 {
   "scripts": {
-    "types": "tsc -p tsconfig.json --declaration --emitDeclarationOnly --outDir ./dist",
+    "types": "tsc -p tsconfig.types.json",
     "prepare": "npm run types && npm run build"
   }
 }

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "target": "ES2020",
+    // This is needed since we use both 'esnext' and 'node' module resolution.
+    // https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies
+    "moduleResolution": "node",
+    "lib": ["dom", "ES2020", "ESNext"],
+    // Treat JSX as React.
+    "jsx": "react",
+    // Make sure CommonJS modules are read correctly.
+    "esModuleInterop": true,
+    // Significant perf increase by skipping checking .d.ts files.
+    "skipLibCheck": true
+  }
+}

--- a/example/tsconfig.types.json
+++ b/example/tsconfig.types.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/*", "src/**/*"] 
+}

--- a/example/types.sh
+++ b/example/types.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+../node_modules/.bin/tsc -p tsconfig.types.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/typehead",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1886,6 +1886,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1890,7 +1890,8 @@
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
     "esbuild": "^0.14.19",
-    "esbuild-plugin-lodash": "^1.1.0",
-    "typescript": "^4.6.3"
+    "esbuild-plugin-lodash": "^1.1.0"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix",
@@ -50,7 +49,8 @@
     "eslint-config-prettier": "^8.3.0",
     "lint-staged": "^11.1.2",
     "lodash": "^4.17.21",
-    "prettier": "^2.3.2"
+    "prettier": "^2.3.2",
+    "typescript": "^4.6.3"
   },
   "engines": {
     "node": ">=14.17.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/typehead",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Refreshingly simple CLI for TypeScript packages.",
   "main": "index.mjs",
   "type": "module",
@@ -30,7 +30,8 @@
     "cosmiconfig": "^7.0.1",
     "deepmerge": "^4.2.2",
     "esbuild": "^0.14.19",
-    "esbuild-plugin-lodash": "^1.1.0"
+    "esbuild-plugin-lodash": "^1.1.0",
+    "typescript": "^4.6.3"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": "eslint --fix",

--- a/src/util/getEsbuildConfig.mjs
+++ b/src/util/getEsbuildConfig.mjs
@@ -20,10 +20,9 @@ export async function getEsbuildConfig() {
     console.debug('Skipping typehead config, using defaults.');
   }
 
-  return deepmerge(configFile, {
+  const config = deepmerge(configFile, {
     sourcemap: true,
     bundle: true,
-    platform: 'neutral',
     plugins: [
       // Automatically rewrite Lodash statements.
       lodashPlugin({
@@ -31,4 +30,11 @@ export async function getEsbuildConfig() {
       }),
     ],
   });
+
+  // Only set platform if not set by the configuration.
+  if (!config.platform) {
+    config.platform = 'neutral';
+  }
+
+  return config;
 }


### PR DESCRIPTION
# Description

- Adds some further docs to the README, stop recommending dts-bundle-generator (just use tsc instead).
- Allow for specifing `"platform": "node"` in the config without it being overwritten.