### PR TITLE
Fix esbuild.serve port argument

### DIFF
--- a/src/serve.mjs
+++ b/src/serve.mjs
@@ -47,7 +47,7 @@ const server = await esbuild.serve(
     host: argv.host || 'localhost',
     // "it will default to an open port with a preference for port 8000"
     // https://esbuild.github.io/api/#serve-arguments
-    port: argv.port || undefined,
+    port: parseInt(argv.port, 10) || undefined,
   },
   config
 );


### PR DESCRIPTION
resovles [ERROR] "port" must be an integer